### PR TITLE
Bumped php 7.0 to php 7.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.0-apache
+FROM php:7.4-apache
 
 MAINTAINER Hugo van Duijn <hugo.vanduijn@naturalis.nl>
 LABEL Description="LAMP stack, modified for naturalis linnaeusng application." 
@@ -14,12 +14,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	    libbz2-dev \
 	    libzip-dev \
         openssh-client \
-        vim \
         locales-all \
         nodejs \
         && \
-    pecl install xdebug \
-    && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -45,7 +42,6 @@ RUN { \
 # add files into container
 ADD linnaeus_repo.key /root/.ssh/id_rsa
 ADD config/php.ini /usr/local/etc/php/
-ADD config/xdebug.ini /usr/local/etc/php/conf.d
 ADD docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 ADD config/apache-config.conf /etc/apache2/sites-enabled/000-default.conf
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   linnaeus:
-    image: "naturalis/linnaeus:0.0.3"
+    image: "naturalis/linnaeus:0.0.4"
     restart: unless-stopped
     env_file:
       - .env


### PR DESCRIPTION
Update van de php omgeving van linnaeus van php 7.0 naar php 7.4 als basis voor [LINNA-1274](https://jira.naturalis.nl/browse/LINNA-1274). Mijn voorstel is deze docker image te bouwen en te pushen naar docker hub met versienummer 0.0.4

Ik heb xdebug even verwijderd, aangezien ik de enige ben die dat gebruikt (Ruud werkt liever met MAMP/XAMP).

Verder zit ik te dubben of ik dit project niet gelijk ook maar naar gitlab moet halen zodat ik de ci/cd pipeline kan gebruiken om daar de docker image te bouwen. Maar ik vind eigenlijk dat dit dit buiten de scope van het issue valt.